### PR TITLE
TypeError: Cannot read property 'setVolume' of undefined

### DIFF
--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -406,12 +406,9 @@ export class TNSPlayer implements TNSPlayerI {
             TNS_Player_Log("this._lastPlayerVolume", this._lastPlayerVolume);
             // if last volume more than 10 just set to 1.0 float
             if (this._lastPlayerVolume && this._lastPlayerVolume >= 10) {
-              this._player.setVolume(1.0, 1.0);
+              this.volume = 1.0;
             } else if (this._lastPlayerVolume) {
-              this._player.setVolume(
-                parseFloat("0." + this._lastPlayerVolume.toString()),
-                parseFloat("0." + this._lastPlayerVolume.toString())
-              );
+              this.volume = parseFloat("0." + this._lastPlayerVolume.toString());
             }
 
             this.resume();
@@ -434,7 +431,7 @@ export class TNSPlayer implements TNSPlayerI {
             // Lower the volume, keep playing
             this._lastPlayerVolume = this.volume;
             TNS_Player_Log("this._lastPlayerVolume", this._lastPlayerVolume);
-            this._player.setVolume(0.2, 0.2);
+            this.volume = 0.2;
             break;
         }
       }


### PR DESCRIPTION
Getting several of these in my crash reporter. Since the `volume` setter is already type-safe and removes the need to pass the value redundantly, this also makes it cleaner.
```
Exception com.tns.NativeScriptException: Calling js method onAudioFocusChange failed TypeError: Cannot read property 'setVolume' of undefined File: "<embedded>, line: 36, column: 2103308 StackTrace: Frame: function:'onAudioFocusChange', file:'<embedded>', line: 36, column: 2103309
com.tns.Runtime.callJSMethodNative (Runtime.java)
com.tns.Runtime.dispatchCallJSMethodNative (Runtime.java:1088)
com.tns.Runtime.callJSMethodImpl (Runtime.java:970)
com.tns.Runtime.callJSMethod (Runtime.java:957)
com.tns.Runtime.callJSMethod (Runtime.java:941)
com.tns.Runtime.callJSMethod (Runtime.java:933)
com.tns.gen.android.media.AudioManager_OnAudioFocusChangeListener.onAudioFocusChange (AudioManager_OnAudioFocusChangeListener.java:11)
android.media.AudioManager$FocusEventHandlerDelegate$1.handleMessage (AudioManager.java:2358)
android.os.Handler.dispatchMessage (Handler.java:102)
android.os.Looper.loop (Looper.java:211)
android.app.ActivityThread.main (ActivityThread.java:5371)
java.lang.reflect.Method.invoke (Method.java)
java.lang.reflect.Method.invoke (Method.java:372)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:945)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:740)
```