### PR TITLE
added ios .DuckOthers category option and deactivate session on dispose

### DIFF
--- a/src/ios/player.ts
+++ b/src/ios/player.ts
@@ -72,12 +72,16 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
         this._infoCallback = options.infoCallback;
 
         let audioSession = AVAudioSession.sharedInstance();
-        audioSession.setCategoryWithOptionsError(AVAudioSessionCategoryPlayAndRecord, AVAudioSessionCategoryOptions.DuckOthers);
+        audioSession.setCategoryWithOptionsError(
+          AVAudioSessionCategoryAmbient,
+          AVAudioSessionCategoryOptions.DuckOthers
+        );
         let output = audioSession.currentRoute.outputs.lastObject.portType;
         TNS_Player_Log('output', output);
 
         if (output.match(/Receiver/)) {
           try {
+            audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
             audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverride.Speaker);
             audioSession.setActiveError(true);
             TNS_Player_Log('audioSession category set and active');
@@ -157,11 +161,15 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
             this._infoCallback = options.infoCallback;
 
             let audioSession = AVAudioSession.sharedInstance();
-          audioSession.setCategoryWithOptionsError(AVAudioSessionCategoryPlayAndRecord, AVAudioSessionCategoryOptions.DuckOthers);
+            audioSession.setCategoryWithOptionsError(
+              AVAudioSessionCategoryAmbient,
+              AVAudioSessionCategoryOptions.DuckOthers
+            );
             let output = audioSession.currentRoute.outputs.lastObject.portType;
 
             if (output.match(/Receiver/)) {
               try {
+                audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
                 audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverride.Speaker);
                 audioSession.setActiveError(true);
                 TNS_Player_Log('audioSession category set and active');

--- a/src/ios/player.ts
+++ b/src/ios/player.ts
@@ -72,12 +72,12 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
         this._infoCallback = options.infoCallback;
 
         let audioSession = AVAudioSession.sharedInstance();
+        audioSession.setCategoryWithOptionsError(AVAudioSessionCategoryPlayAndRecord, AVAudioSessionCategoryOptions.DuckOthers);
         let output = audioSession.currentRoute.outputs.lastObject.portType;
         TNS_Player_Log('output', output);
 
         if (output.match(/Receiver/)) {
           try {
-            audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
             audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverride.Speaker);
             audioSession.setActiveError(true);
             TNS_Player_Log('audioSession category set and active');
@@ -157,11 +157,11 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
             this._infoCallback = options.infoCallback;
 
             let audioSession = AVAudioSession.sharedInstance();
+          audioSession.setCategoryWithOptionsError(AVAudioSessionCategoryPlayAndRecord, AVAudioSessionCategoryOptions.DuckOthers);
             let output = audioSession.currentRoute.outputs.lastObject.portType;
 
             if (output.match(/Receiver/)) {
               try {
-                audioSession.setCategoryError(AVAudioSessionCategoryPlayAndRecord);
                 audioSession.overrideOutputAudioPortError(AVAudioSessionPortOverride.Speaker);
                 audioSession.setActiveError(true);
                 TNS_Player_Log('audioSession category set and active');
@@ -282,6 +282,8 @@ export class TNSPlayer extends NSObject implements TNSPlayerI {
         if (this._player && this.isAudioPlaying()) {
           this._player.stop();
         }
+        var audioSession = AVAudioSession.sharedInstance();
+        audioSession.setActiveError(false);
         this._reset();
         resolve();
       } catch (ex) {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-audio",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "NativeScript plugin to record and play audio.",
   "main": "audio",
   "typings": "index.d.ts",


### PR DESCRIPTION
In existing version of plugin if you have system music playing (e.g. Music app or Spotify), the music will stop once you start playing a sound, and won't resume after the sound finished playing - unless you manually resume it in the music app.
I added the category option [AVAudioSessionCategoryOptions.DuckOthers](https://developer.apple.com/documentation/avfoundation/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionduckothers?language=objc) to the AVAudioSession to allow the music volume to be temporarily decreased while the sound plays, and return to normal once the sound finishes playing. 
I also had to deactivate the audio session in the dispose method to get this to work properly.