### PR TITLE
Fix android audio focus management

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ export class YourClass {
 
   constructor() {
     this._player = new TNSPlayer();
+    // You can pass a duration hint to control the behavior of other application that may
+    // be holding audio focus.
+    // For example: new  TNSPlayer(AudioFocusDurationHint.AUDIOFOCUS_GAIN_TRANSIENT);
+    // Then when you play a song, the previous owner of the
+    // audio focus will stop. When your song stops
+    // the previous holder will resume.
     this._player.debug = true; // set true to enable TNSPlayer console logs for debugging.
     this._player
       .initFromFile({

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -195,6 +195,13 @@ export declare class TNSPlayer {
    */
   readonly currentTime: number;
 
+  /**
+   * @param  {AudioFocusDurationHint} durationHint - Determines differents behaviors by
+   * the system and the other application that previously held audio focus.
+   * See the {@link https://developer.android.com/reference/android/media/AudioFocusRequest#the-different-types-of-focus-requests different  types of focus requests}
+   */
+  constructor(durationHint?: AudioFocusDurationHint);
+
   initFromFile(options: AudioPlayerOptions): Promise<any>;
 
   /**
@@ -328,4 +335,39 @@ export interface IAudioPlayerEvents {
   paused: 'paused';
   started: 'started';
 }
+
 export const AudioPlayerEvents: IAudioPlayerEvents;
+
+export enum AudioFocusDurationHint {
+  /**
+   * Expresses the fact that your application is now the sole source
+   * of audio that the user is listening to. The duration of the
+   * audio playback is unknown, and is possibly very long: after the
+   * user finishes interacting with your application, (s)he doesn’t
+   * expect another audio stream to resume.
+   */
+  AUDIOFOCUS_GAIN = android.media.AudioManager.AUDIOFOCUS_GAIN,
+  /**
+   * For a situation when you know your application is temporarily
+   * grabbing focus from the current owner, but the user expects
+   * playback to go back to where it was once your application no
+   * longer requires audio focus.
+   */
+  AUDIOFOCUS_GAIN_TRANSIENT = android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+  /**
+   * This focus request type is similar to AUDIOFOCUS_GAIN_TRANSIENT
+   * for the temporary aspect of the focus request, but it also
+   * expresses the fact during the time you own focus, you allow
+   * another application to keep playing at a reduced volume,
+   * “ducked”.
+   */
+  AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK = android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+  /**
+   * Also for a temporary request, but also expresses that your
+   * application expects the device to not play anything else. This
+   * is typically used if you are doing audio recording or speech
+   * recognition, and don’t want for examples notifications to be
+   * played by the system during that time.
+   */
+  AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE = android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -105,3 +105,10 @@ export const AudioPlayerEvents = {
   paused: 'paused',
   started: 'started'
 };
+
+export enum AudioFocusDurationHint {
+  AUDIOFOCUS_GAIN = android.media.AudioManager.AUDIOFOCUS_GAIN,
+  AUDIOFOCUS_GAIN_TRANSIENT = android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+  AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK = android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+  AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE = android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
+}

--- a/src/package.json
+++ b/src/package.json
@@ -126,6 +126,10 @@
     {
       "name": "Richard Smith",
       "url": "https://github.com/DickSmith"
+    },
+    {
+      "name": "Daniel Pereira",
+      "url": "https://github.com/danieldspx"
     }
   ],
   "bugs": {


### PR DESCRIPTION
Everytime we instantiate TNSPlayer() it was requesting the audio focus and not abandoning it (until we call `dispose()` which is not always what we want). This is not recommended according to Android documentation and introduces a bug since this is not the expected behaviour.
Those issues are facing exactly this bug: #142 #137



Android docs states that a well-behaved audio app should manage audio focus according to these general guidelines:

> Call requestAudioFocus() immediately before starting to play and verify that the call returns AUDIOFOCUS_REQUEST_GRANTED. If you design your app as we describe in this guide, the call to requestAudioFocus() should be made in the onPlay() callback of your media session.

> When another app gains audio focus, stop or pause playing, or duck the volume down.

> When playback stops, abandon audio focus.

Therefore this pull request strictly obeys Android docs and fix the problem. **It does not break existing code, only introduces the expected behaviour**. So anyone can update the package and get the expected behaviour. I have also introduced the possibility to pass the durationHint (default is still AUDIOFOCUS_GAIN) to `TNSPlayer` constructor so we can determine differents behaviors by the system and the other application that previously held audio focus. Refer to the [updated README.md ](https://github.com/danieldspx/nativescript-audio/blob/master/README.md#typescript-example).
