### PR TITLE
iOS: Resolve promises when calling play, pause or seekTo

### DIFF
--- a/src/ios/player.ts
+++ b/src/ios/player.ts
@@ -279,8 +279,8 @@ export class TNSPlayer extends Observable implements TNSPlayerI {
       try {
         if (this._player && this._player.playing) {
           this._player.pause();
-          resolve(true);
         }
+        resolve(true);
       } catch (ex) {
         if (this.errorCallback) {
           this.errorCallback({ ex });
@@ -295,8 +295,8 @@ export class TNSPlayer extends Observable implements TNSPlayerI {
       try {
         if (!this.isAudioPlaying()) {
           this._player.play();
-          resolve(true);
         }
+        resolve(true);
       } catch (ex) {
         if (this.errorCallback) {
           this.errorCallback({ ex });
@@ -323,8 +323,8 @@ export class TNSPlayer extends Observable implements TNSPlayerI {
       try {
         if (this._player) {
           this._player.currentTime = time;
-          resolve(true);
         }
+        resolve(true);
       } catch (ex) {
         reject(ex);
       }


### PR DESCRIPTION
Previously when calling the play, pause or seekTo methods when running
on iOS and the player was not in the expected state, the Promise would
never be resolved.

e.g. this line would never complete if already in the playing state:
await player.play()