### PR TITLE
Android: Allow the track to be replayed

### DIFF
--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -424,7 +424,7 @@ export class TNSPlayer implements TNSPlayerI {
 
             if (this._options && !this._options.loop) {
               // Make sure that we abandon audio focus when playback stops
-              this._abandonAudioFocus();
+              this._abandonAudioFocus(true);
             }
           }
         })


### PR DESCRIPTION
When the track completes, abandon the audio focus but don't release the
media player. This allows the track to be played again by calling
seekTo(0) and play(), like you can when running the plugin with iOS.

Previously trying to call methods such as seekTo or play after the track
completed resulted in {"player":{},"error":-38,"extra":0}. The only way
to play the track a second time was to call the init method again.