### PR TITLE
Android: To support older SDKs, don't use android.os.Build.VERSION_CODES

### DIFF
--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -27,7 +27,7 @@ export class TNSPlayer implements TNSPlayerI {
     this._durationHint = durationHint;
 
     // Request audio focus for play back
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+    if (android.os.Build.VERSION.SDK_INT >= 26) {
       const playbackAttributes = new android.media.AudioAttributes.Builder()
         .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
         .setContentType(android.media.AudioAttributes.CONTENT_TYPE_MUSIC)
@@ -332,9 +332,7 @@ export class TNSPlayer implements TNSPlayerI {
       ) as android.media.AudioManager;
 
       // Request audio focus for play back
-      if (
-        android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O
-      ) {
+      if (android.os.Build.VERSION.SDK_INT >= 26) {
         focusResult = am.requestAudioFocus(this._audioFocusRequest);
       } else {
         focusResult = am.requestAudioFocus(
@@ -361,7 +359,7 @@ export class TNSPlayer implements TNSPlayerI {
     const am = ctx.getSystemService(android.content.Context.AUDIO_SERVICE);
     let result = null;
 
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+    if (android.os.Build.VERSION.SDK_INT >= 26) {
       console.log('abandonAudioFocusRequest...', this._audioFocusRequest);
       result = am.abandonAudioFocusRequest(this._audioFocusRequest);
       console.log('abandonAudioFocusRequest...result...', result);


### PR DESCRIPTION
When running Android prior to Oreo, android.os.Build.VERSION_CODES.O
does not exist at runtime and so trying to use it produces an error.
Instead, use the API level number (26) directly.

The VERSION_CODES work in Java code because the compiler replaces them
with the numbers at build time, but that doesn't happen with JavaScript.