### PR TITLE
Android: Fix ducking after track paused on pre-Oreo Android devices

### DIFF
--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -380,7 +380,6 @@ export class TNSPlayer implements TNSPlayerI {
     } else {
       console.log('Failed to abandon audio focus.');
     }
-    this._mOnAudioFocusChangeListener = null;
   }
 
   private _getAndroidContext() {


### PR DESCRIPTION
To reproduce:
1. Start the track in the demo app.
2. Play a sound in another app. (I used the test sound in Google Maps.)
   Notice that the demo app ducks the volume of the playing track.
3. Go back to the demo app. Pause and resume the track.
4. Play a sound in another app again.
   Bug: This time the demo app doesn't change the volume of the track.

Fixed by retaining the _mOnAudioFocusChangeListener when pausing so that
it can be used when resuming again.