### PR TITLE
Android: Don't request audio focus on init

### DIFF
--- a/src/android/player.ts
+++ b/src/android/player.ts
@@ -97,11 +97,6 @@ export class TNSPlayer implements TNSPlayerI {
           options.autoPlay = true;
         }
 
-        // request audio focus, this will setup the onAudioFocusChangeListener
-        if (!options.audioMixing) {
-          this._mAudioFocusGranted = this._requestAudioFocus();
-        }
-
         const audioPath = resolveAudioFilePath(options.audioFile);
         this._player.setAudioStreamType(
           android.media.AudioManager.STREAM_MUSIC
@@ -187,9 +182,11 @@ export class TNSPlayer implements TNSPlayerI {
         console.log('player play()');
         if (this._player && !this._player.isPlaying()) {
           // request audio focus, this will setup the onAudioFocusChangeListener
-          this._mAudioFocusGranted = this._requestAudioFocus();
-          if (!this._mAudioFocusGranted) {
-            throw new Error('Could not request audio focus');
+          if (!this._options.audioMixing) {
+            this._mAudioFocusGranted = this._requestAudioFocus();
+            if (!this._mAudioFocusGranted) {
+              throw new Error('Could not request audio focus');
+            }
           }
 
           this._sendEvent(AudioPlayerEvents.started);


### PR DESCRIPTION
Previously audio focus was requested by the playFromFile method, which
is called during initFromFile and initFromUrl. Getting audio focus this
early means that when an AUDIOFOCUS_GAIN event is received, the track
will start playing even though the caller never requested it to play.

Now the audio focus is not requested until playing the track.

Fixes #111