### PR TITLE
respects options in ios and adds one for AVAudioQuality

### DIFF
--- a/src/android/recorder.ts
+++ b/src/android/recorder.ts
@@ -59,25 +59,26 @@ export class TNSRecorder implements TNSRecordI {
         } else {
           this._recorder = new android.media.MediaRecorder();
         }
-
-        const audioSource = options.source ? options.source : 0;
+        
+        const audioSource = options.source ? options.source : android.media.MediaRecorder.AudioSource.DEFAULT; // https://developer.android.com/reference/android/media/MediaRecorder.AudioSource
         this._recorder.setAudioSource(audioSource);
 
-        const outFormat = options.format ? options.format : 0;
+        const outFormat = options.format ? options.format : android.media.AudioFormat.ENCODING_PCM_16BIT; // https://developer.android.com/reference/android/media/AudioFormat#ENCODING_PCM_16BIT
         this._recorder.setOutputFormat(outFormat);
 
-        const encoder = options.encoder ? options.encoder : 0;
+        const encoder = options.encoder ? options.encoder : android.media.MediaRecorder.AudioEncoder.AAC; // https://developer.android.com/reference/android/media/MediaRecorder.AudioEncoder#AAC
         this._recorder.setAudioEncoder(encoder);
 
         if (options.channels) {
           this._recorder.setAudioChannels(options.channels);
         }
-        if (options.sampleRate) {
-          this._recorder.setAudioSamplingRate(options.sampleRate);
-        }
-        if (options.bitRate) {
-          this._recorder.setAudioEncodingBitRate(options.bitRate);
-        }
+
+        let sampleRate = options.sampleRate ? options.sampleRate : 44100;
+        this._recorder.setAudioSamplingRate(sampleRate);
+
+        let bitRate = options.bitRate ? options.bitRate : 128000;
+        this._recorder.setAudioEncodingBitRate(bitRate);
+        
         if (options.maxDuration) {
           this._recorder.setMaxDuration(options.maxDuration);
         }

--- a/src/options.ts
+++ b/src/options.ts
@@ -93,6 +93,11 @@ export interface AudioRecorderOptions {
   encoder?: any;
 
   /**
+   * Sets the ios audio quality setting. Options are Min|Low|Medium|High|Max. Set to Medium by default.
+   */
+  iosAudioQuality?: string;
+
+  /**
    * Gets or sets the callback when an error occurs with the media recorder.
    * @returns {Object} An object containing the native values for the error callback.
    */

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-audio",
-  "version": "6.2.6",
+  "version": "6.3.0",
   "description": "NativeScript plugin to record and play audio.",
   "main": "audio",
   "typings": "index.d.ts",
@@ -61,6 +61,10 @@
       "name": "Nathan Walker",
       "email": "walkerrunpdx@gmail.com",
       "url": "https://github.com/NathanWalker"
+    },
+    {
+      "name": "Dave Coffin",
+      "url": "https://github.com/davecoffin"
     },
     {
       "name": "Jibon Lawrence Costa",


### PR DESCRIPTION
Adds option details to readme
Adds `iosAudioQuality` which you can use to specific the AVAudioQuality enum.
Respects sampleRate on iOS